### PR TITLE
Initial changes related to pod provisioning and CI/CD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /docs
 /node_modules
 tsconfig.tsbuildinfo
+.idea/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Use latest node LTS base image
+FROM node:lts
+
+# Container config & data dir for volume sharing
+# Defaults to filestorage with /data directory (passed through CMD below)
+RUN mkdir /community-server && mkdir /config && mkdir /data
+
+COPY . /community-server/
+
+WORKDIR /community-server
+RUN npm ci
+
+# This is installed such that envsubst can be used within bootstrap.sh
+RUN apt update && apt-get install gettext-base
+
+# Informs Docker that the container listens on the specified network port at runtime
+EXPOSE 3000
+
+# Set command run by the container
+ENTRYPOINT [ "sh", "/community-server/bin/bootstrap.sh" ]
+

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "$@"
+
+# replace environment variable(s) in root acl
+envsubst < /community-server/templates/root/.acl-template > /community-server/templates/root/.acl
+rm /community-server/templates/root/.acl-template
+
+# replace environment variable(s) in pod template acl
+envsubst < /community-server/templates/pod/.acl-template > /community-server/templates/pod/.acl
+rm /community-server/templates/pod/.acl-template
+
+node /community-server/bin/server.js "$@"

--- a/src/pods/agent/Agent.ts
+++ b/src/pods/agent/Agent.ts
@@ -6,4 +6,9 @@ export type Agent = {
   webId: string;
   name?: string;
   email?: string;
+  // TODO (@joshdcollins) [2022-01-01]:-- these fields were added here because currently the Agent is the only
+  // TODO (@joshdcollins) [2022-01-01]:-- source of values for resource generation.  So although these are not
+  // TODO (@joshdcollins) [2022-01-01]:-- fields that actually part of the Agent's domain, they are entered
+  // TODO (@joshdcollins) [2022-01-01]:-- here to ensure they can be included in generation
+  issuer: string;
 };

--- a/src/pods/agent/AgentJsonParser.ts
+++ b/src/pods/agent/AgentJsonParser.ts
@@ -6,7 +6,7 @@ import type { Agent } from './Agent';
 import { AgentParser } from './AgentParser';
 import Dict = NodeJS.Dict;
 
-const requiredKeys: (keyof Agent)[] = [ 'login', 'webId' ];
+const requiredKeys: (keyof Agent)[] = [ 'login', 'webId', 'issuer' ];
 const optionalKeys: (keyof Agent)[] = [ 'name', 'email' ];
 const agentKeys: Set<keyof Agent> = new Set(requiredKeys.concat(optionalKeys));
 

--- a/templates/pod/.acl-template
+++ b/templates/pod/.acl-template
@@ -14,7 +14,7 @@
 # unless specifically authorized in other .acl resources.
 <#owner>
     a acl:Authorization;
-    acl:agent <{{webId}}> ;
+    acl:agent <{{webId}}>, <${ADMIN_AGENT}>;
     # Optional owner email, to be used for account recovery:
     {{#if email}}acl:agent <mailto:{{{email}}}>;{{/if}}
     # Set the access to the root storage folder itself

--- a/templates/pod/profile/card$.ttl
+++ b/templates/pod/profile/card$.ttl
@@ -1,4 +1,6 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix interop: <http://www.w3.org/ns/solid/interop#> .
+@prefix solid: <http://www.w3.org/ns/solid/terms#> .
 
 <>
     a foaf:PersonalProfileDocument;
@@ -6,5 +8,13 @@
     foaf:primaryTopic <{{webId}}>.
 
 <{{webId}}>
-    a foaf:Person;
-    foaf:name "{{name}}".
+    a foaf:Person ;
+    a ldp:RDFSource ;
+    foaf:name "{{name}}" ;
+    a interop:Agent ;
+    solid:oidcIssuer <{{issuer}}> ;
+    interop:hasApplicationRegistrySet <./profile/application#set> ;
+    interop:hasDataRegistrySet <./profile/data#set> ;
+    interop:hasAccessGrantRegistrySet <./profile/grant#set> ;
+    interop:hasAccessReceiptRegistrySet <./profile/receipt#set> ;
+    interop:hasRemoteDataRegistrySet <./profile/remote#set> .

--- a/templates/root/.acl-template
+++ b/templates/root/.acl-template
@@ -1,0 +1,16 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+<#authorization>
+    a               acl:Authorization;
+    # This environment variable token is replaced by bootstrap.sh using envsubst
+    # This is done because currently there is no configuration/context passed in
+    # for use by AclInitializer (it just copies the file in templates/root/.acl)
+    acl:agent       <${ADMIN_AGENT}>;
+    acl:mode        acl:Read;
+    acl:mode        acl:Write;
+    acl:mode        acl:Append;
+    acl:mode        acl:Delete;
+    acl:mode        acl:Control;
+    acl:accessTo    <./>;
+    acl:default     <./>.

--- a/test/integration/PodCreation.test.ts
+++ b/test/integration/PodCreation.test.ts
@@ -10,7 +10,7 @@ const baseUrl = `http://localhost:${port}/`;
 
 describe('A server with a pod handler', (): void => {
   let server: Server;
-  const agent = { login: 'alice', webId: 'http://test.com/#alice', name: 'Alice Bob' };
+  const agent = { login: 'alice', webId: 'http://test.com/#alice', name: 'Alice Bob', issuer: 'https://issuer.example' };
 
   beforeAll(async(): Promise<void> => {
     const factory = await instantiateFromConfig(

--- a/test/unit/pods/GeneratedPodManager.test.ts
+++ b/test/unit/pods/GeneratedPodManager.test.ts
@@ -24,6 +24,7 @@ describe('A GeneratedPodManager', (): void => {
       login: 'user',
       name: 'first last',
       webId: 'http://secure/webId',
+      issuer: 'https://issuer.example/',
     };
     store = {
       getRepresentation: jest.fn((): any => {

--- a/test/unit/pods/agent/AgentJsonParser.test.ts
+++ b/test/unit/pods/agent/AgentJsonParser.test.ts
@@ -51,12 +51,14 @@ describe('An AgentJsonParser', (): void => {
       login: 'login',
       webId: 'webId',
       name: 'name',
+      issuer: 'issuer',
     }) ]);
     await expect(parser.handle(representation)).resolves
       .toEqual({
         login: 'login',
         webId: 'webId',
         name: 'name',
+        issuer: 'issuer',
       });
   });
 });


### PR DESCRIPTION
- Add an initial Dockerfile (TODO - this is still using local file within container as opposed to something durable)
- Add issuer to Agent and AgentParser such that it can be used in templating
- Add bootstrap.sh which performs some envsubst on ACLs to make use of environment variables